### PR TITLE
Validation for UserId, ProductId, and Rating for CreateRating

### DIFF
--- a/OpenHackTeam8/CreateRating.cs
+++ b/OpenHackTeam8/CreateRating.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using System.Net.Http;
 
 namespace OpenHackTeam8
 {
@@ -29,7 +30,7 @@ namespace OpenHackTeam8
             // Validate userId and productId
 
             // validate rating
-            if (!(rating.Rating >= 0 && rating.Rating <= 5))
+            if (IsRatingRangeNotValid(rating.Rating))
             {
                 return new BadRequestObjectResult("rating must be a number between 0 and 5");
             }
@@ -44,5 +45,9 @@ namespace OpenHackTeam8
 
             return new OkObjectResult(rating);
         }
+
+        public static bool IsRatingRangeNotValid(int rating) =>
+            rating < 0 && rating > 5;
+        
     }
 }

--- a/OpenHackTeam8/CreateRating.cs
+++ b/OpenHackTeam8/CreateRating.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System.Net.Http;
+using System.Net;
 
 namespace OpenHackTeam8
 {
@@ -28,6 +29,20 @@ namespace OpenHackTeam8
             RatingDto rating = JsonConvert.DeserializeObject<RatingDto>(requestBody);
 
             // Validate userId and productId
+            var httpClient = new HttpClient();
+            var userIdResponse = await httpClient.GetAsync("https://serverlessohuser.trafficmanager.net/api/GetUser?userId=" + rating.UserId);
+
+            if (userIdResponse.StatusCode == HttpStatusCode.BadRequest) 
+            {
+                return new BadRequestObjectResult($"userid: {rating.UserId} is not valid");
+            }
+
+            var productIdResponse = await httpClient.GetAsync("https://serverlessohproduct.trafficmanager.net/api/GetProduct?productId=" + rating.ProductId);
+
+            if (productIdResponse.StatusCode == HttpStatusCode.BadRequest)
+            {
+                return new BadRequestObjectResult($"productid: {rating.ProductId} is not valid");
+            }
 
             // validate rating
             if (IsRatingRangeNotValid(rating.Rating))
@@ -49,5 +64,6 @@ namespace OpenHackTeam8
         public static bool IsRatingRangeNotValid(int rating) =>
             rating < 0 && rating > 5;
         
+
     }
 }

--- a/OpenHackTeam8/Validation.cs
+++ b/OpenHackTeam8/Validation.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Net.Http;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace OpenHackTeam8
+{
+
+    public static class Validation
+    {
+        public static string userIdValidationUrl = "https://serverlessohuser.trafficmanager.net/api/GetUser?userId=";
+        public static string productIdValidationUrl = "https://serverlessohproduct.trafficmanager.net/api/GetProduct?productId=";
+
+
+        public static async Task<List<ValidationError>> GetErrors(RatingDto rating)
+        {
+            var httpClient = new HttpClient();
+            
+            var validationErrors = new List<ValidationError>();
+            
+            if (await IsUserIdNotValid(rating.UserId, httpClient)) 
+            {
+                validationErrors.Add(new ValidationError("Invalid UserId", $"The userId {rating.UserId} is not valid."));
+            }
+
+            if (await IsProductIdNotValid(rating.ProductId, httpClient))
+            {
+                validationErrors.Add(new ValidationError("Invalid ProductId", $"The productId {rating.ProductId} is not valid."));
+            }
+
+            if (IsRatingOutOfRange(rating.Rating))
+            {
+                validationErrors.Add(new ValidationError("Out of Range Rating Score", $"The rating of {rating.Rating} is outside the range of 0 and 5."));
+            }
+
+            return validationErrors;
+        }
+
+        public static bool IsRatingOutOfRange(int rating) =>
+            !(rating >= 0 && rating <= 5);
+
+        public static async Task<bool> IsProductIdNotValid(Guid productId, HttpClient httpClient) =>
+            await IsBadRequest("https://serverlessohproduct.trafficmanager.net/api/GetProduct?productId=" + productId, httpClient);
+            
+        public static async Task<bool> IsUserIdNotValid(Guid userId, HttpClient httpClient) =>
+            await IsBadRequest("https://serverlessohuser.trafficmanager.net/api/GetUser?userId=" + userId, httpClient);
+        
+        public static async Task<bool> IsBadRequest(string url, HttpClient httpClient)
+        {
+            var response = await httpClient.GetAsync(url);
+            return response.StatusCode == HttpStatusCode.BadRequest;
+        }
+    }
+}

--- a/OpenHackTeam8/ValidationError.cs
+++ b/OpenHackTeam8/ValidationError.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenHackTeam8
+{
+    public class ValidationError
+    {
+        public string Name { get; set; }
+        public string Message { get; set; }
+
+        public ValidationError(string name, string message) 
+        {
+            Name = name;
+            Message = message;
+        }
+    }
+}


### PR DESCRIPTION
Validation is handled by a GetErrors method in the Validation static class. The method builds up a list of ValidationErrors; if there are any, a bad request is returned by the Function with the list of errors as the payload.

The userId and productId are checked by querying external apis reusing the same httpClient. If the ids are not found, the external apis return 400 (Bad Request) which is what we check to determine validity.

The rating property has to be a value between 0 and 5. Outside that range is makes it invalid.